### PR TITLE
Clase9 parte1 y parte2 python

### DIFF
--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
@@ -54,14 +54,21 @@ class Conexion:
         cls.obtenerPool().putconn(conexion)
         log.debug(f'Regresamos la conexion del pool: {conexion}')
 
+    @classmethod
+    def cerrarConexiones(cls):
+        cls.obtenerPool().closeall()
 
 
 if __name__ == '__main__':
     conexion1 = Conexion.obtenerConexion()
+    Conexion.liberarConexion(conexion1)
     conexion2 = Conexion.obtenerConexion()
+    Conexion.liberarConexion(conexion2)
     conexion3 = Conexion.obtenerConexion()
+    Conexion.liberarConexion(conexion3)
     conexion4 = Conexion.obtenerConexion()
     conexion5 = Conexion.obtenerConexion()
+    conexion6 = Conexion.obtenerConexion() #puedo usar una 6 conexion porquque la conexion 1 2 y 3 estan liberadas. Hay 3 libres.
 
 
 

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
@@ -27,10 +27,6 @@ class Conexion:
         return conexion
 
     @classmethod
-    def obtenerCursor(cls):
-        pass
-
-    @classmethod
     def obtenerPool(cls):
         if cls._pool is None:
             try:

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
@@ -49,6 +49,11 @@ class Conexion:
         else:
             return cls._pool
 
+    @classmethod
+    def liberarConexion(cls, conexion):
+        cls.obtenerPool().putconn(conexion)
+        log.debug(f'Regresamos la conexion del pool: {conexion}')
+
 
 
 if __name__ == '__main__':

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
@@ -1,3 +1,5 @@
+from importlib.metadata import pass_none
+
 from psycopg2 import pool ##renombro como bd
 ## psycopg2 as bd Otra manera de importar el psycopg2
 
@@ -20,7 +22,9 @@ class Conexion:
 
     @classmethod  ##METODO OBTENER CONEXION.
     def obtenerConexion(cls):
-        pass
+        conexion = cls.obtenerPool().getconn()
+        log.debug(f'Conexion obtenida del pool: {conexion}')
+        return conexion
 
     @classmethod
     def obtenerCursor(cls):
@@ -30,9 +34,30 @@ class Conexion:
     def obtenerPool(cls):
         if cls._pool is None:
             try:
-                cls._pool = pool.SimpleConnectionPool()
+                cls._pool = pool.SimpleConnectionPool(cls._MIN_CON,
+                                                      cls._MAX_CON,
+                                                      host=cls._HOST,
+                                                      user=cls._USERNAME,
+                                                      password=cls._PASSWORD,
+                                                      port=cls._DEB_PORT,
+                                                      database=cls._DATABASE)
+                log.debug(f'creación del pool exitosa: {cls._pool}')
+                return cls._pool
+            except Exception as e:
+                log.error(f'Ocurrio un error al obtener el pool: {e}')
+                sys.exit()
+        else:
+            return cls._pool
 
 
 
 if __name__ == '__main__':
-    pass
+    conexion1 = Conexion.obtenerConexion()
+    conexion2 = Conexion.obtenerConexion()
+    conexion3 = Conexion.obtenerConexion()
+    conexion4 = Conexion.obtenerConexion()
+    conexion5 = Conexion.obtenerConexion()
+
+
+
+

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/conexion.py
@@ -1,0 +1,38 @@
+from psycopg2 import pool ##renombro como bd
+## psycopg2 as bd Otra manera de importar el psycopg2
+
+from logger_base import log
+
+import psycopg2 as bd
+#psycopg2 as db otra manera de importar el psycopg2
+from logger_base import log
+import sys
+
+class Conexion:
+    _DATABASE = 'test_bd'
+    _USERNAME = 'ariel'
+    _PASSWORD = 'admin'
+    _DEB_PORT = '5432'
+    _HOST = '127.0.0.1'
+    _MIN_CON = 1
+    _MAX_CON = 5
+    _pool = None
+
+    @classmethod  ##METODO OBTENER CONEXION.
+    def obtenerConexion(cls):
+        pass
+
+    @classmethod
+    def obtenerCursor(cls):
+        pass
+
+    @classmethod
+    def obtenerPool(cls):
+        if cls._pool is None:
+            try:
+                cls._pool = pool.SimpleConnectionPool()
+
+
+
+if __name__ == '__main__':
+    pass

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/cursor_del_pool.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/cursor_del_pool.py
@@ -1,0 +1,24 @@
+from logger_base import log
+from conexion import Conexion
+class CursorDelPool:
+    def __init__(self):
+        self._conexion = None
+        self._cursor = None
+
+    def __enter__(self):
+        log.debug('Inicio del metodo with y __enter__')
+        self._conexion = Conexion.obtenerConexion()
+        self._cursor = self._conexion.cursor()
+        return self._cursor
+
+    def __exit__(self, tipo_exception, valor_exception, detalle_exception):
+        log.debug('Se ejecuta el método exit')
+        if valor_exception:
+            self._conexion.rollback()
+            log.debug(f'Ocurrio una excepcion: {valor_exception}')
+        else:
+            self._conexion.commit()
+            log.debug('Commit de la transacion')
+        self._cursor.close()
+        Conexion.liberarConexion(self._conexion)
+

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/cursor_del_pool.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/cursor_del_pool.py
@@ -22,3 +22,8 @@ class CursorDelPool:
         self._cursor.close()
         Conexion.liberarConexion(self._conexion)
 
+if __name__ == '__main__':
+    with CursorDelPool() as cursor:
+        log.debug('Dentro del bloque with')
+        cursor.execute('SELECT * FROM persona')
+        log.debug(cursor.fetchall())

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/logger_base.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/logger_base.py
@@ -1,0 +1,20 @@
+import logging as log
+# log = logging es lo mismo que arriba
+
+#https://docs.python.org/3/howto/logging.html
+#LLAMAMOS A UNA CONFIGURACION BASICA
+
+log.basicConfig(level=log.DEBUG,
+                format='%(asctime)s:%(levelname)s [%(filename)s:%(lineno)s] %(message)s',
+                datefmt='%I:%M:%S %p',
+                handlers=[
+                    log.FileHandler('capa_datos.log'),
+                    log.StreamHandler()
+                ])
+
+if __name__ == '__main__':
+    log.debug('Mensaje a nivel debug')
+    log.info('Mensaje a nivel info')
+    log.warning('Mensaje a nivel warning')
+    log.error('Mensaje a nivel error')
+    log.critical('Mensaje a nivel critical')

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona.py
@@ -1,5 +1,6 @@
 from logger_base import log
 
+
 class Persona:
     def __init__(self, id_persona=None, nombre=None, apellido=None, email=None):
         self._id_persona = id_persona
@@ -15,7 +16,7 @@ class Persona:
             Email: {self._email}
         '''
 
-    #Metodos Getters and Setters
+    # Metodos Getters and Setters
     @property
     def id_persona(self):
         return self._id_persona
@@ -44,15 +45,18 @@ class Persona:
     def email(self):
         return self._email
 
+    # CORRECCIÓN: Se cambió el nombre de la función de 'apellido' a 'email'
     @email.setter
-    def apellido(self, email):
+    def email(self, email):
         self._email = email
 
 
 if __name__ == '__main__':
     persona1 = Persona(1, 'Juan', 'Perez', 'jperez@gmail.com')
     log.debug(persona1)
+
     persona2 = Persona(nombre='Jose', apellido='Lepez', email='ljose@gmail.com')
     log.debug(persona2)
-    persona1 = Persona(id_persona = 1)
+
+    persona1 = Persona(id_persona=1)
     log.debug(persona1)

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona.py
@@ -1,0 +1,58 @@
+from logger_base import log
+
+class Persona:
+    def __init__(self, id_persona=None, nombre=None, apellido=None, email=None):
+        self._id_persona = id_persona
+        self._nombre = nombre
+        self._apellido = apellido
+        self._email = email
+
+    def __str__(self):
+        return f'''
+            Id Persona: {self._id_persona},
+            Nombre: {self._nombre},
+            Apellido: {self._apellido},
+            Email: {self._email}
+        '''
+
+    #Metodos Getters and Setters
+    @property
+    def id_persona(self):
+        return self._id_persona
+
+    @id_persona.setter
+    def id_persona(self, id_persona):
+        self._id_persona = id_persona
+
+    @property
+    def nombre(self):
+        return self._nombre
+
+    @nombre.setter
+    def nombre(self, nombre):
+        self._nombre = nombre
+
+    @property
+    def apellido(self):
+        return self._apellido
+
+    @apellido.setter
+    def apellido(self, apellido):
+        self._apellido = apellido
+
+    @property
+    def email(self):
+        return self._email
+
+    @email.setter
+    def apellido(self, email):
+        self._email = email
+
+
+if __name__ == '__main__':
+    persona1 = Persona(1, 'Juan', 'Perez', 'jperez@gmail.com')
+    log.debug(persona1)
+    persona2 = Persona(nombre='Jose', apellido='Lepez', email='ljose@gmail.com')
+    log.debug(persona2)
+    persona1 = Persona(id_persona = 1)
+    log.debug(persona1)

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona_dao.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona_dao.py
@@ -1,4 +1,5 @@
 from conexion import Conexion
+from cursor_del_pool import CursorDelPool
 from persona import Persona
 from logger_base import log
 
@@ -20,41 +21,37 @@ class PersonaDAO:
 
     @classmethod
     def seleccionar(cls):
-        with Conexion.obtenerConexion():
-            with Conexion.obtenerCursor() as cursor:
-                cursor.execute(cls._SELECCIONAR)
-                registros = cursor.fetchall()
-                personas = []
-                for registro in registros:
-                    persona = Persona(registro[0], registro[2], registro[3])
-                    personas.append(persona)
-                return personas
+        with CursorDelPool() as cursor:
+            cursor.execute(cls._SELECCIONAR)
+            registros = cursor.fetchall()
+            personas = []
+            for registro in registros:
+                persona = Persona(registro[0], registro[1], registro[2], registro[3])
+                personas.append(persona)
+            return personas
 
     @classmethod
     def insertar(cls, persona):
-        with Conexion.obtenerConexion():
-            with Conexion.obtenerCursor() as cursor:
-                valores = (persona.nombre, persona.apellido, persona.email)
-                cursor.execute(cls._INSERTAR, valores)
-                log.debug(f'Persona Insertada: {persona}')
-                return cursor.rowcount
+        with CursorDelPool() as cursor:
+            valores = (persona.nombre, persona.apellido, persona.email)
+            cursor.execute(cls._INSERTAR, valores)
+            log.debug(f'Persona Insertada: {persona}')
+            return cursor.rowcount
     @classmethod
     def actualizar(cls, persona):
-        with Conexion.obtenerConexion():
-            with Conexion.obtenerCursor() as cursor:
-                valores = (persona.nombre, persona.apellido, persona.email, persona.id_persona)
-                cursor.execute(cls._ACTUALIZAR, valores)
-                log.debug(f'Persona actualizada: {persona}')
-                return cursor.rowcount
+        with CursorDelPool() as cursor:
+            valores = (persona.nombre, persona.apellido, persona.email, persona.id_persona)
+            cursor.execute(cls._ACTUALIZAR, valores)
+            log.debug(f'Persona actualizada: {persona}')
+            return cursor.rowcount
 
     @classmethod
     def eliminar(cls, persona):
-        with Conexion.obtenerConexion():
-            with Conexion.obtenerCursor() as cursor:
-                valores = (persona.id_persona,)
-                cursor.execute(cls._ELIMINAR, valores)
-                log.debug(f'Los objetos eliinados son: {persona}')
-                return cursor.rowcount
+        with CursorDelPool() as cursor:
+            valores = (persona.id_persona,)
+            cursor.execute(cls._ELIMINAR, valores)
+            log.debug(f'Los objetos eliinados son: {persona}')
+            return cursor.rowcount
 
 
 if __name__ == '__main__':

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona_dao.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona_dao.py
@@ -1,0 +1,79 @@
+from conexion import Conexion
+from persona import Persona
+from logger_base import log
+
+class PersonaDAO:
+    """
+    DAO significa: Data Access Object
+    CRUD significa:
+                    Create -> Insertar
+                    Read -> Seleccionar
+                    Update -> Actualizar
+                    Delete -> Eliminar
+    """
+    _SELECCIONAR = 'SELECT * FROM persona ORDER BY id_persona'
+    _INSERTAR = 'INSERT INTO persona(nombre, apellido, email) VALUES (%s, %s, %s)'
+    _ACTUALIZAR ='UPDATE persona SET nombre=%s, apellido=%s, email=%s WHERE id_persona=%s'
+    _ELIMINAR = 'DELETE FROM persona WHERE  id_persona=%s'
+
+    # Definimos los métodos de clase
+
+    @classmethod
+    def seleccionar(cls):
+        with Conexion.obtenerConexion():
+            with Conexion.obtenerCursor() as cursor:
+                cursor.execute(cls._SELECCIONAR)
+                registros = cursor.fetchall()
+                personas = []
+                for registro in registros:
+                    persona = Persona(registro[0], registro[2], registro[3])
+                    personas.append(persona)
+                return personas
+
+    @classmethod
+    def insertar(cls, persona):
+        with Conexion.obtenerConexion():
+            with Conexion.obtenerCursor() as cursor:
+                valores = (persona.nombre, persona.apellido, persona.email)
+                cursor.execute(cls._INSERTAR, valores)
+                log.debug(f'Persona Insertada: {persona}')
+                return cursor.rowcount
+    @classmethod
+    def actualizar(cls, persona):
+        with Conexion.obtenerConexion():
+            with Conexion.obtenerCursor() as cursor:
+                valores = (persona.nombre, persona.apellido, persona.email, persona.id_persona)
+                cursor.execute(cls._ACTUALIZAR, valores)
+                log.debug(f'Persona actualizada: {persona}')
+                return cursor.rowcount
+
+    @classmethod
+    def eliminar(cls, persona):
+        with Conexion.obtenerConexion():
+            with Conexion.obtenerCursor() as cursor:
+                valores = (persona.id_persona,)
+                cursor.execute(cls._ELIMINAR, valores)
+                log.debug(f'Los objetos eliinados son: {persona}')
+                return cursor.rowcount
+
+
+if __name__ == '__main__':
+    #Eliminar un registro
+    #persona1 = Persona(id_persona=5)
+    #persona_eliminadas = PersonaDAO.eliminar(persona1)
+    #log.debug(f'Personas eliminadas: {persona_eliminadas}')
+
+    # Actualizar un registro
+    #persona1 = Persona(1, 'Juan José', 'Pena', 'jjpena@mail.com')
+    #personas_actualizadas = PersonaDAO.actualizar(persona1)
+    #log.debug(f'Personas actualizadas: {personas_actualizadas}')
+
+    # Insertar un registro
+    #persona1 = Persona(nombre='Omero', apellido='Ramos', email='omeror@gmail.com')
+    #personas_insertadas = PersonaDAO.insertar(persona1)
+    #log.debug(f'Personas insertadas: {personas_insertadas}')
+
+    # Seleccionar objetos
+    personas = PersonaDAO.seleccionar()
+    for persona in personas:
+        log.debug(persona)

--- a/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona_dao.py
+++ b/Python/Clase 9 Pool de conexiones con Python y Postgresql Parte 1/capa_datos_persona/persona_dao.py
@@ -26,7 +26,12 @@ class PersonaDAO:
             registros = cursor.fetchall()
             personas = []
             for registro in registros:
-                persona = Persona(registro[0], registro[1], registro[2], registro[3])
+                persona = Persona(
+                    id_persona=registro[0],
+                    nombre=registro[1],
+                    apellido=registro[2],
+                    email=registro[3]
+                )
                 personas.append(persona)
             return personas
 
@@ -56,19 +61,19 @@ class PersonaDAO:
 
 if __name__ == '__main__':
     #Eliminar un registro
-    #persona1 = Persona(id_persona=5)
-    #persona_eliminadas = PersonaDAO.eliminar(persona1)
-    #log.debug(f'Personas eliminadas: {persona_eliminadas}')
+    persona1 = Persona(id_persona=18)
+    persona_eliminadas = PersonaDAO.eliminar(persona1)
+    log.debug(f'Personas eliminadas: {persona_eliminadas}')
 
     # Actualizar un registro
-    #persona1 = Persona(1, 'Juan José', 'Pena', 'jjpena@mail.com')
-    #personas_actualizadas = PersonaDAO.actualizar(persona1)
-    #log.debug(f'Personas actualizadas: {personas_actualizadas}')
+    persona1 = Persona(1, 'Juan', 'Pena', 'jpena@mail.com')
+    personas_actualizadas = PersonaDAO.actualizar(persona1)
+    log.debug(f'Personas actualizadas: {personas_actualizadas}')
 
     # Insertar un registro
-    #persona1 = Persona(nombre='Omero', apellido='Ramos', email='omeror@gmail.com')
-    #personas_insertadas = PersonaDAO.insertar(persona1)
-    #log.debug(f'Personas insertadas: {personas_insertadas}')
+    persona1 = Persona(nombre='Mateo', apellido='Torres', email='tmateo@gmail.com')
+    personas_insertadas = PersonaDAO.insertar(persona1)
+    log.debug(f'Personas insertadas: {personas_insertadas}')
 
     # Seleccionar objetos
     personas = PersonaDAO.seleccionar()


### PR DESCRIPTION
## Descripción
Este Pull Request incluye la implementación del Pool de Conexiones con Python y PostgreSQL, correspondiente a los temas abordados en la Clase 9. Además, soluciona un error crítico de asignación en el modelo `Persona` que afectaba la integridad de los datos al interactuar con la base de datos.

## Cambios realizados (Features)
* **Gestión del Pool de Conexiones:** Implementación del Connection Pool utilizando la librería Psycopg2 para optimizar el rendimiento y el manejo de múltiples clientes.
* **Control de Conexiones:** Se añadieron los métodos necesarios para obtener una conexión del pool, así como para liberar y cerrar las conexiones adecuadamente.
* **Clase `CursorDelPool`:** Creación e integración de la clase `CursorDelPool` para manejar los cursores de forma segura mediante *context managers* (bloque `with`), junto con sus respectivas pruebas de funcionamiento.
* **Integración y Pruebas DAO:** Se adaptó la clase `PersonaDAO` para utilizar el nuevo pool y se completaron las pruebas de las operaciones CRUD (insertar, seleccionar, actualizar, eliminar).

## Correcciones (Bugfixes)
* **Fallo en atributo `email`:** Se corrigió un error tipográfico en el archivo `persona.py` donde el *setter* de la propiedad `email` estaba nombrado erróneamente como `def apellido(self, email):`. Esto provocaba que el campo apellido se sobrescribiera con el correo electrónico al momento de instanciar el objeto y realizar un `INSERT`.
* **Mapeo de datos en DAO:** Se normalizó la lectura de índices en el método `PersonaDAO.seleccionar()` (`registro[2]` para apellido, `registro[3]` para email) para que coincida con el constructor corregido del modelo.

## ⚠️ Notas para el Revisor / Tareas pendientes
* Debido al bug solucionado en el *setter* del email, **es necesario limpiar o actualizar manualmente la base de datos local de PostgreSQL**. Los registros insertados durante las pruebas previas (ej. IDs 14 y 15) quedaron persistidos en la base de datos con correos electrónicos en la columna `apellido` y deberán ser purgados para que las consultas `SELECT` muestren información coherente.

Closes #150  Closes #151  Closes #152  Closes #153 Closes #154  Closes #155 Closes #156  Closes #157 